### PR TITLE
Make a fulltext element if SCRIPT or STYLE tags in sexp representation

### DIFF
--- a/plump-sexp.lisp
+++ b/plump-sexp.lisp
@@ -41,7 +41,11 @@
            (:!ROOT
             (loop for child in blocks
                   do (transform-sexp child root)))
-           (T (let ((node (make-element root (name->string tag))))
+           (T (let ((node (funcall (if (member tag '(SCRIPT STYLE)
+                                               :test #'string-equal)
+                                       #'make-fulltext-element
+                                       #'make-element)
+                                   root (name->string tag))))
                 (loop for (key val) on attributes by #'cddr
                       do (setf (attribute node (name->string key))
                                (princ-to-string val)))


### PR DESCRIPTION
`<script>` and `<style>` tags shouldn't escape HTML entities like regular plump elements do. This pull request fixes the `transform-sexp` behavior to reflect that.

I don't love this implementation because it hard-codes SCRIPT and STYLE (though I think those are the only ones that should be fulltext elements), so if you have a better idea for implementation I'm willing to work toward implementing it. I know spinneret uses `:raw` pseudo elements to turn off HTML entity escaping, so that's another option. 